### PR TITLE
Version 1.1.0. Added UMD wrapper and unit tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
+#########################
+# Development Ignores
+#########################
+/.idea/
+/guacamole-common-js.iml
 *~
 target/
 nb-configuration.xml
 guacamole/customs.json
+
+#########################
+# External Library Ignores
+#########################
+node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# guacamole-common-js changelog
+
+## 1.1.0 (Guacamole Version: 0.9.9)
+
+* Updated package.json to include a `main` section that points to a UMD file that loads guacamole
+ source as AMD, CommonJS, or a global variable
+* Added [tape](https://github.com/substack/tape) unit test library and a simple CommonJS test
+
+## 1.0.0 (Guacamole Version: 0.9.9)
+
+* Initial version release

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ library __guacamole-common-js__. In addition, I have converted it to a NPM repos
 npm install --save padarom-guacamole-common-js
 ```
 
+## How to use this fork
+
+This fork includes a [UMD](https://github.com/umdjs/umd) wrapper to export the `Guacamole` object
+ in CommonJS format, AMD format, or as a 'global' object (when used in browser).  For CommonJS, 
+ simply require this library:
+ 
+```
+var Guacamole = require('padarom-guacamole-common-js');
+// All modules are now exposed:
+var tunnel = new Guacamole.HTTPTunnel(..., ...);
+```
+
 ## Documentation
 Distribution-specific packages are available from the files section of the main
 project page:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,26 @@
+var fs = require('fs');
+
+(function (root, factory) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD. Register as an anonymous module.
+		define([], factory);
+	} else if (typeof module === 'object' && module.exports) {
+		// Node. Does not work with strict CommonJS, but
+		// only CommonJS-like environments that support module.exports,
+		// like Node.
+		module.exports = factory();
+	} else {
+		// Browser globals (root is window)
+		root.Guacamole = factory();
+	}
+}(this, function () {
+
+	// Use the eval function to load and evaluate the guacamole-common.js file, which will now
+	// create the local variable Guacamole in this scope, which we can "export" below
+	eval(fs.readFileSync('./dist/guacamole-common.js','utf8'));
+
+	// Just return a value to define the module export.
+	// This example returns an object, but the module
+	// can return a function as the exported value.
+	return Guacamole;
+}));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "padarom-guacamole-common-js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "The JavaScript Guacamole client as a NPM package",
+  "main": "dist/index.js",
+  "scripts": {
+    "test": "npm install; tape test/**/*.test.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Padarom/guacamole-common-js.git"
@@ -23,5 +27,8 @@
   "bugs": {
     "url": "https://github.com/Padarom/guacamole-common-js/issues"
   },
-  "homepage": "https://github.com/Padarom/guacamole-common-js#readme"
+  "homepage": "https://github.com/Padarom/guacamole-common-js#readme",
+  "devDependencies": {
+    "tape": "^4.6.3"
+  }
 }

--- a/test/commonjs.test.js
+++ b/test/commonjs.test.js
@@ -1,0 +1,37 @@
+var test = require('tape');
+const fs = require('fs');
+
+var Guacamole = require('..');
+
+test('commonjs test', function (t) {
+	t.ok(Guacamole != null, 'Guacamole should be defined');
+
+	t.ok(Guacamole.ArrayBufferReader != null, 'Guacamole should define module: ArrayBufferReader');
+	t.ok(Guacamole.ArrayBufferWriter != null, 'Guacamole should define module: ArrayBufferWriter');
+	t.ok(Guacamole.AudioContextFactory != null, 'Guacamole should define module: AudioContextFactory');
+	t.ok(Guacamole.AudioPlayer != null, 'Guacamole should define module: AudioPlayer');
+	t.ok(Guacamole.AudioRecorder != null, 'Guacamole should define module: AudioRecorder');
+	t.ok(Guacamole.BlobReader != null, 'Guacamole should define module: BlobReader');
+	t.ok(Guacamole.BlobWriter != null, 'Guacamole should define module: BlobWriter');
+	t.ok(Guacamole.Client != null, 'Guacamole should define module: Client');
+	t.ok(Guacamole.DataURIReader != null, 'Guacamole should define module: DataURIReader');
+	t.ok(Guacamole.Display != null, 'Guacamole should define module: Display');
+	t.ok(Guacamole.InputStream != null, 'Guacamole should define module: InputStream');
+	t.ok(Guacamole.IntegerPool != null, 'Guacamole should define module: IntegerPool');
+	t.ok(Guacamole.JSONReader != null, 'Guacamole should define module: JSONReader');
+	t.ok(Guacamole.Keyboard != null, 'Guacamole should define module: Keyboard');
+	t.ok(Guacamole.Layer != null, 'Guacamole should define module: Layer');
+	t.ok(Guacamole.Mouse != null, 'Guacamole should define module: Mouse');
+	t.ok(Guacamole.Object != null, 'Guacamole should define module: Object');
+	t.ok(Guacamole.OnScreenKeyboard != null, 'Guacamole should define module: OnScreenKeyboard');
+	t.ok(Guacamole.OutputStream != null, 'Guacamole should define module: OutputStream');
+	t.ok(Guacamole.Parser != null, 'Guacamole should define module: Parser');
+	t.ok(Guacamole.RawAudioFormat != null, 'Guacamole should define module: RawAudioFormat');
+	t.ok(Guacamole.Status != null, 'Guacamole should define module: Status');
+	t.ok(Guacamole.StringReader != null, 'Guacamole should define module: StringReader');
+	t.ok(Guacamole.StringWriter != null, 'Guacamole should define module: StringWriter');
+	t.ok(Guacamole.Tunnel != null, 'Guacamole should define module: Tunnel');
+	t.ok(Guacamole.VideoPlayer != null, 'Guacamole should define module: VideoPlayer');
+
+	t.end();
+});


### PR DESCRIPTION
Updated to add a UMD wrapper to make the Guac common JS easier to use in CommonJS, AMD, and Browser environments.

Wrote a simple test.

I'm not sure about the version...I suggested a bump to 1.1 since this is a somewhat big change (not breaking but definitely adds more than just bug fixes).

However, perhaps it would be better to align this version number to the actual Guacamole source it's based on (so 0.9.9)? Now sure how bad that would screw things up for others currently using this...or if NPM even allows/likes that.