### PR TITLE
Change representation of ü in the package.json author field

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ssh",
     "telnet"
   ],
-  "author": "Christopher Mühl <christopher@padarom.io>",
+  "author": "Christopher MÃ¼hl <christopher@padarom.io>",
   "license": "Apache 2.0",
   "bugs": {
     "url": "https://issues.apache.org/jira/browse/GUACAMOLE/"


### PR DESCRIPTION
The "ü" character in the "author" field was represented using the
character 0xfc. This is correct for Unicode, but is an invalid character
in UTF-8. From https://en.wikipedia.org/wiki/Specials_(Unicode_block):
> The first and last byte are valid UTF-8 encodings of ASCII, but the
> middle byte (0xFC) is not a valid byte in UTF-8.

The presence of 0xFC is a problem because it causes tools that are
strict about JSON files having UTF-8 encoding to fail.